### PR TITLE
Change 'update-file' to only write a new file if there are changes.

### DIFF
--- a/src/main/clojure/clojure/tools/namespace/move.clj
+++ b/src/main/clojure/clojure/tools/namespace/move.clj
@@ -21,9 +21,13 @@
 
 (defn- update-file
   "Reads file as a string, calls f on the string plus any args, then
-  writes out return value of f as the new contents of file."
+  writes out return value of f as the new contents of file. Does not
+  write to file if the contents would not be changed."
   [file f & args]
-  (spit file (str (apply f (slurp file) args))))
+  (let [old (slurp file)
+        new (str (apply f old args))]
+    (when (not= old new)
+      (spit file new))))
 
 (defn- ns-file-name [sym]
   (str (-> (name sym)


### PR DESCRIPTION
Hi.

Thanks for tools.namespace — really useful.

I was annoyed that `move-ns` changes the timestamps on files whose content doesn't change; this fixes that.

This is my first ever pull request (apart from an earlier one for this change that I screwed up and deleted). Apologies if anything's not right.

I couldn't find any tests to modify. If I've missed something let me know.

Regards,
Simon Katz
