### PR TITLE
Avoid checking namespaces that were already checked

### DIFF
--- a/src/main/clojure/clojure/tools/namespace/dependency.clj
+++ b/src/main/clojure/clojure/tools/namespace/dependency.clj
@@ -46,10 +46,12 @@
 (defn- transitive
   "Recursively expands the set of dependency relationships starting
   at (get m x)"
-  [m x]
-  (reduce (fn [s k]
-	    (set/union s (transitive m k)))
-	  (get m x) (get m x)))
+  ([m x]
+     (transitive m x #{}))
+  ([depmap ns checked-deps]
+     (reduce (fn [checked-deps ns]
+               (set/union checked-deps #{ns} (transitive depmap ns checked-deps)))
+             checked-deps (set/difference (get depmap ns) checked-deps))))
 
 (declare depends?)
 


### PR DESCRIPTION
in dependency/transitive, this tracks the list of namespaces that were already checked, and doesn't check them again. Provides a massive speedup for me on a large project (20kLoC, ~120 lein dependencies). 

I'm not sure how contributions work for an 'official' clojure project, I have a CA signed as 'Allen Rohner'. 
