### PR TITLE
Fix mention of warnings about aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ un/reloading those namespaces.
 
 Use this feature sparingly: it exists as a development-time
 convenience, not a work-around for code that is not reload-safe. Also,
-see the warnings about aliases, below. Aliases to reloaded namespaces
+see the [warnings about aliases](#warnings-for-aliases). Aliases to reloaded namespaces
 will break if the namespace *containing* the alias is not reloaded
 also.
 


### PR DESCRIPTION
The text may have been rearranged at some point, making the "below" description for the location of the mentioned info invalid. I linked the text to the section mentioned.