### PR TITLE
Expose scan-refresh-dirs in c.t.n.repl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target
 .cpcache
 .idea/
 *.iml
+/.lsp
+/.clj-kondo

--- a/src/main/clojure/clojure/tools/namespace/repl.clj
+++ b/src/main/clojure/clojure/tools/namespace/repl.clj
@@ -80,6 +80,19 @@
     (when (find-ns ns-name)
       (alias alias-sym ns-name))))
 
+(defn scan-refresh-dirs
+  "Scans refresh-dirs for files which have changed, removing disabled namespace
+  from the result. See `clojure.tools.namespace.dirs/scan` for specific
+  documentation on scan-opts."
+  ([]
+   (scan-refresh-dirs nil))
+  ([scan-opts]
+   (scan-refresh-dirs refresh-tracker scan-opts))
+  ([tracker scan-opts]
+   (-> tracker
+       (dir/scan-dirs refresh-dirs scan-opts)
+       (remove-disabled))))
+
 (defn- do-refresh [scan-opts after-sym]
   (when after-sym
     (assert (symbol? after-sym) ":after value must be a symbol")
@@ -88,8 +101,7 @@
   (let [current-ns-name (ns-name *ns*)
         current-ns-refers (referred *ns*)
         current-ns-aliases (aliased *ns*)]
-    (alter-var-root #'refresh-tracker dir/scan-dirs refresh-dirs scan-opts)
-    (alter-var-root #'refresh-tracker remove-disabled)
+    (alter-var-root #'refresh-tracker scan-refresh-dirs)
     (print-pending-reloads refresh-tracker)
     (alter-var-root #'refresh-tracker reload/track-reload)
     (in-ns current-ns-name)


### PR DESCRIPTION
External consumers of clojure.tools.namespace.repl might want to know what namespaces are pending reload in order to determine if any actions need to be taken on the pending namespaces prior to refresh; e.g. stopping stateful resources. Prior to this change, the alter-var-root logic would have to duplicated into local code; this makes it simpler to introspect what the next state of the refresh tracker will be from consuming code.

I didn't see any automated tests for the repl namespace, but I have manually run through common usage in a REPL.