### PR TITLE
Fix incorrect type hint in read-ns-decl-from-jarfile-entry

### DIFF
--- a/src/main/clojure/clojure/tools/namespace/find.clj
+++ b/src/main/clojure/clojure/tools/namespace/find.clj
@@ -12,12 +12,10 @@
   clojure.tools.namespace.find
   (:require [clojure.java.classpath :as classpath]
             [clojure.java.io :as io]
-            [clojure.set :as set]
             [clojure.tools.namespace.file :as file]
             [clojure.tools.namespace.parse :as parse])
-  (:import (java.io File FileReader BufferedReader PushbackReader
-                    InputStreamReader)
-           (java.util.jar JarFile JarEntry)))
+  (:import (java.io File PushbackReader)
+           (java.util.jar JarFile)))
 
 (set! *warn-on-reflection* true)
 
@@ -92,7 +90,7 @@
            (let [[_ nom & more :as decl] (file/read-file-ns-decl % (:read-opts platform))]
              (when (and decl nom (symbol? nom))
                (list* 'ns (with-meta nom
-                            {:dir (.getName ^java.io.File dir) :file (.getName ^java.io.File %)})
+                                     {:dir (.getName ^File dir) :file (.getName ^File %)})
                       more))))
          (find-sources-in-dir dir platform))))
 
@@ -156,7 +154,7 @@
        (ignore-reader-exception
         (let [[_ nom & more] (parse/read-ns-decl rdr read-opts)]
           (list* 'ns (with-meta nom
-                       {:jar (.getName ^java.io.File jarfile) :file entry-name})
+                       {:jar (.getName ^JarFile jarfile) :file entry-name})
                  more)))))))
 
 (defn find-ns-decls-in-jarfile

--- a/src/main/clojure/clojure/tools/namespace/find.clj
+++ b/src/main/clojure/clojure/tools/namespace/find.clj
@@ -90,7 +90,7 @@
            (let [[_ nom & more :as decl] (file/read-file-ns-decl % (:read-opts platform))]
              (when (and decl nom (symbol? nom))
                (list* 'ns (with-meta nom
-                                     {:dir (.getName ^File dir) :file (.getName ^File %)})
+                            {:dir (.getName ^File dir) :file (.getName ^File %)})
                       more))))
          (find-sources-in-dir dir platform))))
 


### PR DESCRIPTION
I believe the type hint in `read-ns-decl-from-jarfile-entry` in the `(.getName ^java.io.File jarfile)` breaks this function. To reproduce, call it with any jar file as input. Examples:

```clojure
(let [filename (format "%s/.m2/repository/org/clojure/tools.namespace/1.4.2/tools.namespace-1.4.2.jar" (System/getenv "HOME"))
      jarfile (JarFile. (io/file filename))]
  (clojure.tools.namespace.find/find-ns-decls-in-jarfile jarfile))
``` 

This should give the exception:
```
Error printing return value (ClassCastException) at clojure.tools.namespace.find/read-ns-decl-from-jarfile-entry (find.clj:158).
class java.util.jar.JarFile cannot be cast to class java.io.File (java.util.jar.JarFile and java.io.File are in module java.base of loader 'bootstrap')
```

The base failure mode can be reproduced with:
```clojure
(let [filename (format "%s/.m2/repository/org/clojure/tools.namespace/1.4.2/tools.namespace-1.4.2.jar" (System/getenv "HOME"))
      jarfile (JarFile. (io/file filename))]
  (.getName ^java.io.File jarfile))
```

The fix looks to just be using the right hint:
```clojure
(let [filename (format "%s/.m2/repository/org/clojure/tools.namespace/1.4.2/tools.namespace-1.4.2.jar" (System/getenv "HOME"))
      jarfile (JarFile. (io/file filename))]
  (.getName ^java.util.jar.JarFile jarfile))
```

This PR fixes the hint and does some minor cleanup (linting and shorter references on hints for classes that are already imported).